### PR TITLE
Fetch from origin/master

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+pyinstaller scanline-build.spec
+mv dist/aicli /usr/local/bin/scandev

--- a/reviewme/ailinter/ailinter.py
+++ b/reviewme/ailinter/ailinter.py
@@ -154,12 +154,14 @@ def get_chat_completion_messages_for_review(code, full_file_content):
 ############################
 
 def get_files_changed(target):
+    EXCLUDED_EXTENSIONS = ['.snap', ".pyc"]
     # Get list of all files that changed on this git branch compared to main
     file_paths_changed = os.popen("git diff --name-only {0} 2>/dev/null".format(target)).read().split("\n")
     # add . prefix to all files
     result = []
     for file_path in file_paths_changed:
-        if file_path != "":
+        file_extension = os.path.splitext(file_path)[1]
+        if file_path != "" and file_extension not in EXCLUDED_EXTENSIONS:
             result.append("./" + file_path)
 
     return result
@@ -216,13 +218,13 @@ def run(scope, onlyReviewThisFile):
         diffs = get_file_diffs(file_paths_changed, "HEAD~0")
     elif scope == "branch":
         try:
-            file_paths_changed = get_files_changed("master")
-            diffs = get_file_diffs(file_paths_changed, "master")
+            file_paths_changed = get_files_changed("origin/master")
+            diffs = get_file_diffs(file_paths_changed, "origin/master")
         except Exception as e:
             pass
         try:
-            file_paths_changed = get_files_changed("main")
-            diffs = get_file_diffs(file_paths_changed, "main")
+            file_paths_changed = get_files_changed("origin/main")
+            diffs = get_file_diffs(file_paths_changed, "origin/main")
         except Exception as e:
             pass
     elif scope == "repo":

--- a/reviewme/ailinter/ailinter.py
+++ b/reviewme/ailinter/ailinter.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import subprocess
 import os, sys
 from dotenv import load_dotenv
 from pprint import pprint 
@@ -153,10 +154,24 @@ def get_chat_completion_messages_for_review(code, full_file_content):
 ## LLM call and Prompt 
 ############################
 
+def get_main_branch_name():
+    # Get the name of the main branch (either main or master)
+    result = subprocess.run(
+        "git ls-remote --heads origin | grep 'refs/heads/main'",
+        shell=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+    if result.stdout:
+        return "main"
+    else:
+        return "master"
+
 def get_files_changed(target):
     EXCLUDED_EXTENSIONS = ['.snap', ".pyc"]
     # Get list of all files that changed on this git branch compared to main
-    file_paths_changed = os.popen("git diff --name-only {0} 2>/dev/null".format(target)).read().split("\n")
+    file_paths_changed = os.popen("git diff --name-only {0}".format(target)).read().split("\n")
     # add . prefix to all files
     result = []
     for file_path in file_paths_changed:
@@ -171,8 +186,8 @@ def get_file_diffs(file_paths, target):
 
     file_diffs = {}
     for file_path in file_paths:
-            file_diffs[file_path] = os.popen("git diff --unified=0 {0} {1} 2>/dev/null".format(target, file_path)).read()
-            # print("git diff --unified=0 {0} {1}".format(target, file_path))
+            file_diffs[file_path] = os.popen("git diff --unified=0 {0} {1}".format(target, file_path)).read()
+            print("git diff --unified=0 {0} {1}".format(target, file_path))
     # print(file_diffs)
     return file_diffs
 
@@ -217,14 +232,16 @@ def run(scope, onlyReviewThisFile):
         file_paths_changed = get_files_changed("HEAD~0")
         diffs = get_file_diffs(file_paths_changed, "HEAD~0")
     elif scope == "branch":
+        main_branch_name = get_main_branch_name()
+        remote_branch_name = f"origin/{main_branch_name}"
         try:
-            file_paths_changed = get_files_changed("origin/master")
-            diffs = get_file_diffs(file_paths_changed, "origin/master")
+            file_paths_changed = get_files_changed(remote_branch_name)
+            diffs = get_file_diffs(file_paths_changed, remote_branch_name)
         except Exception as e:
             pass
         try:
-            file_paths_changed = get_files_changed("origin/main")
-            diffs = get_file_diffs(file_paths_changed, "origin/main")
+            file_paths_changed = get_files_changed(remote_branch_name)
+            diffs = get_file_diffs(file_paths_changed, remote_branch_name)
         except Exception as e:
             pass
     elif scope == "repo":
@@ -343,7 +360,7 @@ def run(scope, onlyReviewThisFile):
     STREAMLIT_APP_PATH = os.path.join(base_dir, config['STREAMLIT_LOCAL_PATH'])
 
     # Run the streamlit app: Port and app filepath are loaded from config. The current Review's csv filepath is passed as its argument
-    os.system(f"streamlit run --server.port {config['STREAMLIT_APP_PORT']} {STREAMLIT_APP_PATH} -- {absolute_csv_file_path} 2>/dev/null")
+    os.system(f"streamlit run --server.port {config['STREAMLIT_APP_PORT']} {STREAMLIT_APP_PATH} -- {absolute_csv_file_path}")
     ### End streamlit dashboard 
 
 if __name__ == "__main__":

--- a/reviewme/ailinter/ailinter.py
+++ b/reviewme/ailinter/ailinter.py
@@ -187,7 +187,7 @@ def get_file_diffs(file_paths, target):
     file_diffs = {}
     for file_path in file_paths:
             file_diffs[file_path] = os.popen("git diff --unified=0 {0} {1}".format(target, file_path)).read()
-            print("git diff --unified=0 {0} {1}".format(target, file_path))
+            # print("git diff --unified=0 {0} {1}".format(target, file_path))
     # print(file_diffs)
     return file_diffs
 

--- a/reviewme/cli.py
+++ b/reviewme/cli.py
@@ -9,9 +9,9 @@ logging.basicConfig(level=logging.WARN)
 @click.pass_context
 def cli(ctx):
     if ctx.invoked_subcommand is None:
-        print ("👨🏻‍💻 Starting AI code review on branch")
+        print ("👨🏻‍💻 Starting AI code review on branch", flush=True)
         ailinter.run("branch", "")
-        print ("✅ Code review complete.")
+        print ("✅ Code review complete.", flush=True)
 
 @click.command()
 @click.option('--scope', default="branch", help='Scope of code review. Can be "commit", "branch", or "repo". Defaults to "branch"')


### PR DESCRIPTION
**Problem**

On active repositories, a developer's local copy of master quickly gets out of date and developers usually update their working branch with `git pull origin master`, which brings the current branch up to date but leaves local master stale. Then when running scanline, it triggers searching through tons of extra files since the working branch has many changes that local master does not have. 

This was causing performance to be very slow and almost broken for me.

**Solution**

I propose we compare branches against origin/master